### PR TITLE
Add Compose DSL module

### DIFF
--- a/compose-dsl/README.md
+++ b/compose-dsl/README.md
@@ -1,0 +1,28 @@
+# Compose DSL Module
+
+This module provides a minimal Jetpack Compose implementation of the DSL engine
+used in the Swift version of the project. The architecture mirrors the iOS
+implementation with `DSLContext`, `DSLInterpreter`, `DSLAppEngine` and the
+corresponding registries for commands, operators and UI components.
+
+## Building and Running
+
+1. Open the `compose-dsl` directory in Android Studio.
+2. Ensure that the Android Gradle Plugin and Kotlin version support Jetpack
+   Compose (AGP 8+ recommended).
+3. Build and run the `sample` module on an Android device or emulator.
+   The sample `MainActivity` loads `app.compiled.json` from the Android assets
+   and renders the resulting UI.
+
+A basic `build.gradle` file is expected with Compose dependencies. For brevity,
+this repository does not ship a full Gradle wrapper.
+
+## Limitations
+
+* Only a subset of the operators from `DLSKit/Operators` has been implemented
+  in Kotlin. Additional operators can be registered following the same pattern.
+* Component modifiers are minimal and only cover basic layout. More modifiers
+  can be added by extending the component builders.
+* JSON parsing relies on `org.json` and expects an `app.compiled.json` file in
+  the app assets folder.
+

--- a/compose-dsl/build.gradle.kts
+++ b/compose-dsl/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.ComposeDSL"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.ComposeDSL.sample"
+        minSdk = 24
+        targetSdk = 34
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation("androidx.compose.material3:material3:1.1.2")
+}

--- a/compose-dsl/settings.gradle.kts
+++ b/compose-dsl/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "ComposeDSL"
+include(":app")

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/ButtonComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/ButtonComponent.kt
@@ -1,0 +1,22 @@
+package com.example.ComposeDSL
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+object ButtonComponent {
+    fun register() {
+        DSLComponentRegistry.register("button") { node, context ->
+            val titleExpr = node["title"]
+            val title = DSLExpression.evaluate(titleExpr, context)?.toString() ?: ""
+            val action = node["onTap"]
+            Button(onClick = { action?.let { DSLInterpreter.shared.handleEvent(it, context) } }) {
+                if (node["children"] is List<*>) {
+                    DSLRenderer.renderChildren(node["children"] as List<Map<String, Any?>>, context)
+                } else {
+                    Text(title)
+                }
+            }
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/ColumnComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/ColumnComponent.kt
@@ -1,0 +1,15 @@
+package com.example.ComposeDSL
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+
+object ColumnComponent {
+    fun register() {
+        DSLComponentRegistry.register("vstack") { node, context ->
+            Column {
+                val children = node["children"] as? List<Map<String, Any?>> ?: emptyList()
+                DSLRenderer.renderChildren(children, context)
+            }
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLAppEngine.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLAppEngine.kt
@@ -1,0 +1,52 @@
+package com.example.ComposeDSL
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+object DSLAppEngine {
+    var initialScreenId: String? = null
+    val screens = mutableMapOf<String, Map<String, Any?>>()
+    var tabDefinitions: List<Map<String, Any?>>? = null
+
+    fun load(context: Context) {
+        val text = context.assets.open("app.compiled.json").bufferedReader().use { it.readText() }
+        val json = JSONObject(text)
+        initialScreenId = json.optString("mainScreen")
+        val screenList = json.optJSONArray("screens") ?: JSONArray()
+        for (i in 0 until screenList.length()) {
+            val obj = screenList.getJSONObject(i)
+            val id = obj.getString("id")
+            screens[id] = obj.toMap()
+        }
+    }
+
+    fun start(context: Context, dslContext: DSLContext, interpreter: DSLInterpreter) {
+        val rawContext = JSONObject(context.assets.open("app.compiled.json").bufferedReader().use { it.readText() }).optJSONObject("context")
+        if (rawContext != null) {
+            rawContext.keys().forEach { key -> dslContext[key] = rawContext.get(key) }
+        }
+        if (initialScreenId != null) {
+            screens[initialScreenId!!]?.let { interpreter.present(it, dslContext) }
+        }
+    }
+
+    fun navigate(id: String) {
+        screens[id]?.let { DSLInterpreter.shared.pushScreen(id) }
+    }
+}
+
+private fun JSONObject.toMap(): Map<String, Any?> {
+    val result = mutableMapOf<String, Any?>()
+    keys().forEach { key ->
+        result[key] = when (val value = get(key)) {
+            is JSONObject -> value.toMap()
+            is JSONArray -> (0 until value.length()).map { index ->
+                val item = value.get(index)
+                if (item is JSONObject) item.toMap() else item
+            }
+            else -> value
+        }
+    }
+    return result
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLCommandRegistry.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLCommandRegistry.kt
@@ -1,0 +1,41 @@
+package com.example.ComposeDSL
+
+object DSLCommandRegistry {
+    private val registry = mutableMapOf<String, (Any?, DSLContext) -> Unit>()
+
+    fun register(name: String, fn: (Any?, DSLContext) -> Unit) {
+        registry[name] = fn
+    }
+
+    fun execute(command: Map<String, Any?>, context: DSLContext) {
+        val name = command.keys.firstOrNull() ?: return
+        val params = command[name]
+        registry[name]?.invoke(params, context)
+    }
+
+    fun registerDefaults() {
+        register("set") { params, ctx ->
+            val map = params as? Map<*, *> ?: return@register
+            val varPath = map["var"] as? String ?: return@register
+            val valueExpr = map["value"]
+            ctx[varPath] = DSLExpression.evaluate(valueExpr, ctx)
+        }
+
+        register("print") { params, ctx ->
+            println("DSL print >>> ${DSLExpression.evaluate(params, ctx)}")
+        }
+
+        register("navigate") { params, ctx ->
+            val screenId = when (params) {
+                is String -> params
+                is Map<*, *> -> DSLExpression.evaluate(params["screenId"], ctx) as? String
+                else -> null
+            }
+            screenId?.let { DSLAppEngine.navigate(it) }
+        }
+
+        register("goBack") { _, _ ->
+            DSLInterpreter.shared.popScreen()
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLComponentRegistry.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLComponentRegistry.kt
@@ -1,0 +1,24 @@
+package com.example.ComposeDSL
+
+import androidx.compose.runtime.Composable
+
+typealias ComponentBuilder = @Composable (node: Map<String, Any?>, context: DSLContext) -> Unit
+
+object DSLComponentRegistry {
+    private val components = mutableMapOf<String, ComponentBuilder>()
+
+    fun register(type: String, builder: ComponentBuilder) {
+        components[type] = builder
+    }
+
+    fun resolve(type: String): ComponentBuilder? = components[type]
+
+    fun registerDefaults() {
+        ButtonComponent.register()
+        TextComponent.register()
+        ImageComponent.register()
+        ColumnComponent.register()
+        RowComponent.register()
+        ListComponent.register()
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLContext.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLContext.kt
@@ -1,0 +1,19 @@
+package com.example.ComposeDSL
+
+import androidx.compose.runtime.mutableStateMapOf
+
+class DSLContext(initial: Map<String, Any?> = emptyMap()) {
+    val storage = mutableStateMapOf<String, Any?>().apply { putAll(initial) }
+    var currentIndex: Int? = null
+
+    operator fun get(key: String): Any? = storage[key]
+    operator fun set(key: String, value: Any?) {
+        storage[key] = value
+    }
+
+    fun childContext(index: Int): DSLContext {
+        val child = DSLContext(storage)
+        child.currentIndex = index
+        return child
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLExpression.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLExpression.kt
@@ -1,0 +1,57 @@
+package com.example.ComposeDSL
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+object DSLExpression {
+    fun evaluate(expr: Any?, context: DSLContext): Any? {
+        when (expr) {
+            null -> return null
+            is Map<*, *> -> {
+                if (expr.size == 1 && expr.containsKey("var")) {
+                    val path = expr["var"] as? String
+                    return path?.let { resolvePath(it, context) }
+                }
+                val opName = expr.keys.firstOrNull() as? String
+                val input = expr[opName]
+                if (opName != null && DSLOperatorRegistry.isRegistered(opName)) {
+                    val evaluatedInput = if (input is List<*>) {
+                        input.map { evaluate(it, context) }
+                    } else {
+                        evaluate(input, context)
+                    }
+                    return DSLOperatorRegistry.evaluate(opName, evaluatedInput, context)
+                }
+                val result = mutableMapOf<String, Any?>()
+                expr.forEach { (k, v) -> result[k as String] = evaluate(v, context) }
+                return result
+            }
+            is List<*> -> return expr.map { evaluate(it, context) }
+            is JSONArray -> {
+                return (0 until expr.length()).map { evaluate(expr.get(it), context) }
+            }
+            is JSONObject -> {
+                val map = mutableMapOf<String, Any?>()
+                expr.keys().forEach { key -> map[key] = evaluate(expr.get(key), context) }
+                return evaluate(map, context)
+            }
+            else -> return expr
+        }
+    }
+
+    private fun resolvePath(path: String, context: DSLContext): Any? {
+        val parts = path.split(".")
+        var value: Any? = context[parts.firstOrNull() ?: return null]
+        for (part in parts.drop(1)) {
+            value = when (value) {
+                is Map<*, *> -> value[part]
+                is List<*> -> {
+                    val index = part.removeSuffix("]").substringAfter("[").toIntOrNull()
+                    if (index != null && value.size > index) value[index] else null
+                }
+                else -> return null
+            }
+        }
+        return value
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLInterpreter.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLInterpreter.kt
@@ -1,0 +1,31 @@
+package com.example.ComposeDSL
+
+import androidx.compose.runtime.mutableStateListOf
+
+class DSLInterpreter private constructor() {
+    companion object { val shared = DSLInterpreter() }
+
+    val navigationPath = mutableStateListOf<String>()
+    private var currentContext: DSLContext? = null
+    private var rootScreenId: String? = null
+
+    fun present(screen: Map<String, Any?>, context: DSLContext) {
+        currentContext = context
+        rootScreenId = screen["id"] as? String
+        navigationPath.clear()
+    }
+
+    fun pushScreen(id: String) { navigationPath.add(id) }
+    fun popScreen() { if (navigationPath.isNotEmpty()) navigationPath.removeLast() }
+
+    fun handleEvent(event: Any?, context: DSLContext) {
+        when (event) {
+            is Map<*, *> -> DSLCommandRegistry.execute(event as Map<String, Any?>, context)
+            is List<*> -> event.forEach { handleEvent(it, context) }
+        }
+    }
+
+    fun getRootScreenDefinition(): Map<String, Any?>? {
+        return rootScreenId?.let { DSLAppEngine.screens[it] }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLOperatorRegistry.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLOperatorRegistry.kt
@@ -1,0 +1,23 @@
+package com.example.ComposeDSL
+
+object DSLOperatorRegistry {
+    private val registry = mutableMapOf<String, (Any?, DSLContext) -> Any?>()
+
+    fun register(name: String, fn: (Any?, DSLContext) -> Any?) {
+        registry[name] = fn
+    }
+
+    fun evaluate(name: String, input: Any?, context: DSLContext): Any? {
+        val op = registry[name] ?: return null
+        return op(input, context)
+    }
+
+    fun isRegistered(name: String) = registry.containsKey(name)
+
+    fun registerDefaults() {
+        StringOperators.registerAll()
+        MathOperators.registerAll()
+        LogicOperators.registerAll()
+        // Additional operator sets can be added here
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/DSLRenderer.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/DSLRenderer.kt
@@ -1,0 +1,17 @@
+package com.example.ComposeDSL
+
+import androidx.compose.runtime.Composable
+
+object DSLRenderer {
+    @Composable
+    fun renderComponent(node: Map<String, Any?>, context: DSLContext) {
+        val type = node["type"] as? String ?: return
+        val builder = DSLComponentRegistry.resolve(type)
+        builder?.invoke(node, context)
+    }
+
+    @Composable
+    fun renderChildren(nodes: List<Map<String, Any?>>, context: DSLContext) {
+        nodes.forEach { renderComponent(it, context) }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/ImageComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/ImageComponent.kt
@@ -1,0 +1,16 @@
+package com.example.ComposeDSL
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+
+object ImageComponent {
+    fun register() {
+        DSLComponentRegistry.register("image") { node, context ->
+            val name = DSLExpression.evaluate(node["name"], context)?.toString() ?: return@register
+            Image(painter = painterResource(name), contentDescription = null, modifier = Modifier.fillMaxWidth())
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/ListComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/ListComponent.kt
@@ -1,0 +1,20 @@
+package com.example.ComposeDSL
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+
+object ListComponent {
+    fun register() {
+        DSLComponentRegistry.register("list") { node, context ->
+            val data = DSLExpression.evaluate(node["data"], context)
+            val items = data as? List<Map<String, Any?>> ?: emptyList()
+            LazyColumn {
+                itemsIndexed(items) { index, item ->
+                    val childContext = context.childContext(index)
+                    DSLRenderer.renderChildren(listOf(item), childContext)
+                }
+            }
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/LogicOperators.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/LogicOperators.kt
@@ -1,0 +1,32 @@
+package com.example.ComposeDSL
+
+object LogicOperators {
+    fun registerAll() {
+        DSLOperatorRegistry.register("Logic.eq") { input, _ ->
+            val list = input as? List<*> ?: return@register false
+            if (list.size != 2) return@register false
+            list[0] == list[1]
+        }
+
+        DSLOperatorRegistry.register("Logic.neq") { input, _ ->
+            val list = input as? List<*> ?: return@register true
+            if (list.size != 2) return@register true
+            list[0] != list[1]
+        }
+
+        DSLOperatorRegistry.register("Logic.and") { input, _ ->
+            val list = input as? List<*> ?: return@register false
+            list.all { it as? Boolean ?: false }
+        }
+
+        DSLOperatorRegistry.register("Logic.or") { input, _ ->
+            val list = input as? List<*> ?: return@register false
+            list.any { it as? Boolean ?: false }
+        }
+
+        DSLOperatorRegistry.register("Logic.not") { input, _ ->
+            val bool = input as? Boolean ?: return@register false
+            !bool
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/MathOperators.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/MathOperators.kt
@@ -1,0 +1,46 @@
+package com.example.ComposeDSL
+
+import kotlin.random.Random
+
+object MathOperators {
+    fun registerAll() {
+        DSLOperatorRegistry.register("Math.add") { input, _ ->
+            val list = input as? List<*> ?: return@register 0.0
+            list.sumOf { (it as? Number)?.toDouble() ?: 0.0 }
+        }
+
+        DSLOperatorRegistry.register("Math.subtract") { input, _ ->
+            val list = input as? List<*> ?: return@register 0.0
+            val nums = list.mapNotNull { (it as? Number)?.toDouble() }
+            if (nums.isEmpty()) return@register 0.0
+            nums.drop(1).fold(nums.first()) { acc, d -> acc - d }
+        }
+
+        DSLOperatorRegistry.register("Math.multiply") { input, _ ->
+            val list = input as? List<*> ?: return@register 0.0
+            list.mapNotNull { (it as? Number)?.toDouble() }.fold(1.0) { acc, d -> acc * d }
+        }
+
+        DSLOperatorRegistry.register("Math.divide") { input, _ ->
+            val list = input as? List<*> ?: return@register 0.0
+            val nums = list.mapNotNull { (it as? Number)?.toDouble() }
+            if (nums.size != 2 || nums[1] == 0.0) return@register 0.0
+            nums[0] / nums[1]
+        }
+
+        DSLOperatorRegistry.register("Math.mod") { input, _ ->
+            val list = input as? List<*> ?: return@register 0
+            val a = (list.getOrNull(0) as? Number)?.toInt() ?: return@register 0
+            val b = (list.getOrNull(1) as? Number)?.toInt() ?: return@register 0
+            if (b == 0) 0 else a % b
+        }
+
+        DSLOperatorRegistry.register("Math.random") { input, context ->
+            val args = input as? List<*> ?: return@register 0
+            if (args.size < 2) return@register 0
+            val min = (DSLExpression.evaluate(args[0], context) as? Number)?.toDouble() ?: 0.0
+            val max = (DSLExpression.evaluate(args[1], context) as? Number)?.toDouble() ?: 0.0
+            if (min > max) Random.nextDouble(max, min) else Random.nextDouble(min, max)
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/RowComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/RowComponent.kt
@@ -1,0 +1,15 @@
+package com.example.ComposeDSL
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+
+object RowComponent {
+    fun register() {
+        DSLComponentRegistry.register("hstack") { node, context ->
+            Row {
+                val children = node["children"] as? List<Map<String, Any?>> ?: emptyList()
+                DSLRenderer.renderChildren(children, context)
+            }
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/StringOperators.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/StringOperators.kt
@@ -1,0 +1,36 @@
+package com.example.ComposeDSL
+
+object StringOperators {
+    fun registerAll() {
+        DSLOperatorRegistry.register("String.trim") { input, _ ->
+            (input as? String)?.trim()
+        }
+
+        DSLOperatorRegistry.register("String.uppercase") { input, _ ->
+            (input as? String)?.uppercase()
+        }
+
+        DSLOperatorRegistry.register("String.add") { input, _ ->
+            val list = input as? List<*> ?: return@register ""
+            list.joinToString(separator = "") { it?.toString() ?: "" }
+        }
+
+        DSLOperatorRegistry.register("String.indexOf") { input, _ ->
+            val dict = input as? Map<*, *> ?: return@register -1
+            val text = dict["source"] as? String ?: return@register -1
+            val search = dict["search"] as? String ?: return@register -1
+            text.indexOf(search)
+        }
+
+        DSLOperatorRegistry.register("String.substring") { input, context ->
+            val args = input as? List<*> ?: return@register ""
+            if (args.size < 3) return@register ""
+            val src = DSLExpression.evaluate(args[0], context) as? String ?: return@register ""
+            val start = (DSLExpression.evaluate(args[1], context) as? Number)?.toInt() ?: 0
+            val len = (DSLExpression.evaluate(args[2], context) as? Number)?.toInt() ?: 0
+            if (start < 0 || len < 0 || start > src.length) return@register ""
+            val end = (start + len).coerceAtMost(src.length)
+            src.substring(start, end)
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/TextComponent.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/TextComponent.kt
@@ -1,0 +1,13 @@
+package com.example.ComposeDSL
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+object TextComponent {
+    fun register() {
+        DSLComponentRegistry.register("text") { node, context ->
+            val value = DSLExpression.evaluate(node["value"], context)
+            Text(value?.toString() ?: "")
+        }
+    }
+}

--- a/compose-dsl/src/main/java/com/example/ComposeDSL/sample/MainActivity.kt
+++ b/compose-dsl/src/main/java/com/example/ComposeDSL/sample/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.example.ComposeDSL.sample
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.example.ComposeDSL.*
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val context = DSLContext()
+        DSLOperatorRegistry.registerDefaults()
+        DSLCommandRegistry.registerDefaults()
+        DSLComponentRegistry.registerDefaults()
+        DSLAppEngine.load(this)
+        DSLAppEngine.start(this, context, DSLInterpreter.shared)
+
+        setContent {
+            val root = DSLInterpreter.shared.getRootScreenDefinition()
+            if (root != null) {
+                DSLRenderer.renderChildren(root["body"] as List<Map<String, Any?>>, context)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port core DSL classes to Jetpack Compose
- implement simple operator registry and sample operators
- add minimal set of Compose components
- add sample `MainActivity` showing loading and rendering `app.compiled.json`
- document how to build the module

## Testing
- `git status --short`